### PR TITLE
feat: add node and edge creation controls

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+type Variant = "default" | "outline" | "info";
+
+const variantClasses: Record<Variant, string> = {
+  default: "bg-slate-900 text-white border-transparent",
+  outline: "bg-white text-slate-700 border border-slate-200",
+  info: "bg-indigo-100 text-indigo-700 border border-indigo-200",
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: Variant;
+}
+
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
+  { className = "", variant = "default", ...props },
+  ref
+) {
+  const base = "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium border";
+  return <span ref={ref} className={`${base} ${variantClasses[variant]} ${className}`.trim()} {...props} />;
+});

--- a/src/types/dagre.d.ts
+++ b/src/types/dagre.d.ts
@@ -1,0 +1,1 @@
+declare module "dagre";


### PR DESCRIPTION
## Summary
- add inline controls to create nodes and edges directly within the UgViewer canvas
- refactor the layout pipeline to reuse shared logic when clustering processes and appending items
- add a local dagre module declaration so the TypeScript lint target passes cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfe3cec4c8832f92032194437e31e3